### PR TITLE
Accept more than one EventId and OrganizationId

### DIFF
--- a/IOF.xsd
+++ b/IOF.xsd
@@ -440,7 +440,7 @@
         <xsd:attribute name="type" type="xsd:string" use="optional">
           <xsd:annotation>
             <xsd:documentation>
-              The issuer of the identity, e.g. World Ranking List.
+              The issuer of the identity, e.g. World Ranking List. Identifiers issued by the International Orienteering Federation (IOF) must have type="IOF".
             </xsd:documentation>
           </xsd:annotation>
         </xsd:attribute>

--- a/IOF.xsd
+++ b/IOF.xsd
@@ -586,7 +586,13 @@
       </xsd:documentation>
     </xsd:annotation>
     <xsd:sequence>
-      <xsd:element name="Id" type="Id" minOccurs="0"/>
+      <xsd:element name="Id" type="Id" minOccurs="0" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            The identifier of the organisation. Multiple identifiers can be included, e.g. when there is both a national federation identifier and an international database identifier for the organisation.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
       <xsd:element name="Name" type="xsd:string">
         <xsd:annotation>
           <xsd:documentation>
@@ -691,7 +697,7 @@
 
   <xsd:complexType name="Event" mixed="false">
     <xsd:sequence>
-      <xsd:element name="Id" type="Id" minOccurs="0"/>
+      <xsd:element name="Id" type="Id" minOccurs="0" maxOccurs="unbounded"/>
       <xsd:element name="Name" type="xsd:string"/>
       <xsd:element name="StartTime" type="DateAndOptionalTime" minOccurs="0">
         <xsd:annotation>


### PR DESCRIPTION
More than one ID can be defined for both an event and an organisation. IDs can be distinguished using the 'type' attribute. This is useful for including IDs from national databases alongside IDs from international databases. This was already possible for the Person entity.

The documentation now specifies that IOF IDs must be marked as type="IOF".

The following entities have the ID element with an implicit maxOccurs="1":
- Class
- ClassType
- Fee
- PersonEntry
- TeamEntry
- Control
- Map
- Course
- SimpleCourse
- Service
- ServiceRequest

However, they are used by internal entities for internal references. The "include Id from multiple external databases" use case doesn't apply.