### PR TITLE
+voided on CourseControl

### DIFF
--- a/IOF.xsd
+++ b/IOF.xsd
@@ -3984,6 +3984,13 @@
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
+    <xsd:attribute name="voided" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation>
+          Indicates that this control has been voided. For Trail-O, this means no answer is correct. For other disciplines, this may indicate control issues that void split times to and from this control.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
     <xsd:attribute name="modifyTime" type="xsd:dateTime" use="optional"/>
   </xsd:complexType>
 


### PR DESCRIPTION
A CourseControl can be marked as voided. Useful for Trail-O and for some edge cases on other disciplined (when you want to void a part of the course - it's actually forbidden by the rules)

This is related to #23 