### PR TITLE
OverTime replaced by ExceedingMaxTime

### DIFF
--- a/IOF.xsd
+++ b/IOF.xsd
@@ -2956,7 +2956,7 @@
           </xsd:documentation>
         </xsd:annotation>
       </xsd:enumeration>
-      <xsd:enumeration value="ExceedingMaxTime">
+      <xsd:enumeration value="ExceededTimeLimit">
         <xsd:annotation>
           <xsd:documentation>
             Did not finish within the maximum time set by the organiser.

--- a/IOF.xsd
+++ b/IOF.xsd
@@ -2956,10 +2956,10 @@
           </xsd:documentation>
         </xsd:annotation>
       </xsd:enumeration>
-      <xsd:enumeration value="OverTime">
+      <xsd:enumeration value="ExceedingMaxTime">
         <xsd:annotation>
           <xsd:documentation>
-            Overtime, i.e. did not finish within the maximum time set by the organiser.
+            Did not finish within the maximum time set by the organiser.
           </xsd:documentation>
         </xsd:annotation>
       </xsd:enumeration>


### PR DESCRIPTION
OverTime has another meaning in english (extra worked hours or extra playing time... not connected to a disqualification)

Breaking change!